### PR TITLE
Add is_closed method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-channel"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 description = "Async multi-producer multi-consumer channel"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,24 @@ impl<T> Sender<T> {
         self.channel.close()
     }
 
+    /// Returns `true` if the channel is closed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # blocking::block_on! {
+    /// use async_channel::{unbounded, RecvError};
+    ///
+    /// let (s, r) = unbounded();
+    /// assert_eq!(s.send(1).await, Ok(()));
+    /// assert!(s.close());
+    /// assert!(s.is_closed() && r.is_closed());
+    /// # }
+    /// ```
+    pub fn is_closed(&self) -> bool {
+        self.channel.queue.is_closed()
+    }
+
     /// Returns `true` if the channel is empty.
     ///
     /// # Examples
@@ -522,6 +540,24 @@ impl<T> Receiver<T> {
     /// ```
     pub fn close(&self) -> bool {
         self.channel.close()
+    }
+
+    /// Returns `true` if the channel is closed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # blocking::block_on! {
+    /// use async_channel::{unbounded, RecvError};
+    ///
+    /// let (s, r) = unbounded();
+    /// assert_eq!(s.send(1).await, Ok(()));
+    /// assert!(s.close());
+    /// assert!(s.is_closed() && r.is_closed());
+    /// # }
+    /// ```
+    pub fn is_closed(&self) -> bool {
+        self.channel.queue.is_closed()
     }
 
     /// Returns `true` if the channel is empty.


### PR DESCRIPTION
I saw that this crate did not have an `is_closed` method to check whether a channel is closed. This seemed rather trivial to implement - simply check whether the underlying queue is closed. However, looks can be deceiving, and I may have missed something! Please let me know if this is the case. I also bumped the version number from 1.2.0 to 1.3.0 to reflect the addition. Again, please let me know if you want this to be undone.