### PR TITLE
Add receiver_count and sender_count methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,6 +383,44 @@ impl<T> Sender<T> {
     pub fn capacity(&self) -> Option<usize> {
         self.channel.queue.capacity()
     }
+
+    /// Returns the number of receivers for the channel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures_lite::future::block_on(async {
+    /// use async_channel::unbounded;
+    ///
+    /// let (s, r) = unbounded::<()>();
+    /// assert_eq!(s.receiver_count(), 1);
+    ///
+    /// let r2 = r.clone();
+    /// assert_eq!(s.receiver_count(), 2);
+    /// # });
+    /// ```
+    pub fn receiver_count(&self) -> usize {
+        self.channel.receiver_count.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of receivers for the channel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures_lite::future::block_on(async {
+    /// use async_channel::unbounded;
+    ///
+    /// let (s, r) = unbounded::<()>();
+    /// assert_eq!(s.sender_count(), 1);
+    ///
+    /// let s2 = s.clone();
+    /// assert_eq!(s.sender_count(), 2);
+    /// # });
+    /// ```
+    pub fn sender_count(&self) -> usize {
+        self.channel.sender_count.load(Ordering::Relaxed)
+    }
 }
 
 impl<T> Drop for Sender<T> {
@@ -640,6 +678,44 @@ impl<T> Receiver<T> {
     /// ```
     pub fn capacity(&self) -> Option<usize> {
         self.channel.queue.capacity()
+    }
+
+    /// Returns the number of receivers for the channel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures_lite::future::block_on(async {
+    /// use async_channel::unbounded;
+    ///
+    /// let (s, r) = unbounded::<()>();
+    /// assert_eq!(r.receiver_count(), 1);
+    ///
+    /// let r2 = r.clone();
+    /// assert_eq!(r.receiver_count(), 2);
+    /// # });
+    /// ```
+    pub fn receiver_count(&self) -> usize {
+        self.channel.receiver_count.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of receivers for the channel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures_lite::future::block_on(async {
+    /// use async_channel::unbounded;
+    ///
+    /// let (s, r) = unbounded::<()>();
+    /// assert_eq!(r.sender_count(), 1);
+    ///
+    /// let s2 = s.clone();
+    /// assert_eq!(r.sender_count(), 2);
+    /// # });
+    /// ```
+    pub fn sender_count(&self) -> usize {
+        self.channel.sender_count.load(Ordering::Relaxed)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,7 +400,7 @@ impl<T> Sender<T> {
     /// # });
     /// ```
     pub fn receiver_count(&self) -> usize {
-        self.channel.receiver_count.load(Ordering::Relaxed)
+        self.channel.receiver_count.load(Ordering::SeqCst)
     }
 
     /// Returns the number of receivers for the channel.
@@ -419,7 +419,7 @@ impl<T> Sender<T> {
     /// # });
     /// ```
     pub fn sender_count(&self) -> usize {
-        self.channel.sender_count.load(Ordering::Relaxed)
+        self.channel.sender_count.load(Ordering::SeqCst)
     }
 }
 
@@ -696,7 +696,7 @@ impl<T> Receiver<T> {
     /// # });
     /// ```
     pub fn receiver_count(&self) -> usize {
-        self.channel.receiver_count.load(Ordering::Relaxed)
+        self.channel.receiver_count.load(Ordering::SeqCst)
     }
 
     /// Returns the number of receivers for the channel.
@@ -715,7 +715,7 @@ impl<T> Receiver<T> {
     /// # });
     /// ```
     pub fn sender_count(&self) -> usize {
-        self.channel.sender_count.load(Ordering::Relaxed)
+        self.channel.sender_count.load(Ordering::SeqCst)
     }
 }
 

--- a/tests/bounded.rs
+++ b/tests/bounded.rs
@@ -247,6 +247,34 @@ fn len() {
 }
 
 #[test]
+fn receiver_count() {
+    let (s, r) = bounded::<()>(5);
+    let receiver_clones: Vec<_> = (0..20).map(|_| r.clone()).collect();
+
+    assert_eq!(s.receiver_count(), 21);
+    assert_eq!(r.receiver_count(), 21);
+
+    drop(receiver_clones);
+
+    assert_eq!(s.receiver_count(), 1);
+    assert_eq!(r.receiver_count(), 1);
+}
+
+#[test]
+fn sender_count() {
+    let (s, r) = bounded::<()>(5);
+    let sender_clones: Vec<_> = (0..20).map(|_| s.clone()).collect();
+
+    assert_eq!(s.sender_count(), 21);
+    assert_eq!(r.sender_count(), 21);
+
+    drop(sender_clones);
+
+    assert_eq!(s.receiver_count(), 1);
+    assert_eq!(r.receiver_count(), 1);
+}
+
+#[test]
 fn close_wakes_sender() {
     let (s, r) = bounded(1);
 

--- a/tests/unbounded.rs
+++ b/tests/unbounded.rs
@@ -174,6 +174,34 @@ fn len() {
 }
 
 #[test]
+fn receiver_count() {
+    let (s, r) = unbounded::<()>();
+    let receiver_clones: Vec<_> = (0..20).map(|_| r.clone()).collect();
+
+    assert_eq!(s.receiver_count(), 21);
+    assert_eq!(r.receiver_count(), 21);
+
+    drop(receiver_clones);
+
+    assert_eq!(s.receiver_count(), 1);
+    assert_eq!(r.receiver_count(), 1);
+}
+
+#[test]
+fn sender_count() {
+    let (s, r) = unbounded::<()>();
+    let sender_clones: Vec<_> = (0..20).map(|_| s.clone()).collect();
+
+    assert_eq!(s.sender_count(), 21);
+    assert_eq!(r.sender_count(), 21);
+
+    drop(sender_clones);
+
+    assert_eq!(s.receiver_count(), 1);
+    assert_eq!(r.receiver_count(), 1);
+}
+
+#[test]
 fn close_wakes_receiver() {
     let (s, r) = unbounded::<()>();
 


### PR DESCRIPTION
Closes #18.

A few questions:
1) Is `Ordering::Relaxed` ok for this? I assume so since we're not coordinating anything, but I'm not an expert on this.
2) Any other test cases I should add in?